### PR TITLE
cpu_freq: cpu_load: Add CPU load measurement

### DIFF
--- a/include/zephyr/cpu_freq/policy.h
+++ b/include/zephyr/cpu_freq/policy.h
@@ -22,11 +22,10 @@ extern "C" {
  * @brief Get the next P-state from CPU Frequency Policy
  *
  * @param p_state Pointer to the P-state struct where the next P-state is returned.
- * @param cpu_load Current CPU load percentage (0-100).
  *
  * @retval 0 In case of success, nonzero in case of failure.
  */
-uint32_t cpu_freq_policy_get_p_state_next(struct p_state *p_state, uint32_t cpu_load);
+int cpu_freq_policy_get_p_state_next(struct p_state *p_state);
 
 #ifdef __cplusplus
 }

--- a/subsys/cpu_freq/CMakeLists.txt
+++ b/subsys/cpu_freq/CMakeLists.txt
@@ -7,6 +7,9 @@ zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 zephyr_library()
 zephyr_library_sources(cpu_freq.c)
 
+# Metrics
+zephyr_sources_ifdef(CONFIG_CPU_FREQ_METRIC_CPU_LOAD metrics/cpu_load.c)
+
 # Policy selection
 if(CONFIG_CPU_FREQ_POLICY_NONE)
   message(FATAL_ERROR "No CPU frequency policy selected. Please choose a valid policy in Kconfig.")

--- a/subsys/cpu_freq/Kconfig
+++ b/subsys/cpu_freq/Kconfig
@@ -4,7 +4,7 @@
 
 menuconfig CPU_FREQ
 	bool "CPU Frequency Scaling Subsystem"
-	# select CPU_LOAD TODO: Select the CPU Load subsystem
+	depends on !SMP
 	help
 	  CPU Frequency scaling subsystem
 
@@ -21,6 +21,16 @@ config CPU_FREQ_INTERVAL_MS
 	  Controls the interval (in milliseconds) at which the CPU Frequency
 	  subsystem runs and evaluates the current policy.
 
+config CPU_FREQ_METRIC_CPU_LOAD
+	bool "Measure CPU Load for Frequency Policies"
+	default n
+	select THREAD_RUNTIME_STATS
+	select SCHED_THREAD_USAGE
+	select SCHED_THREAD_USAGE_ALL
+	select SCHED_THREAD_USAGE_AUTO_ENABLE
+	help
+	  Enable measurement of CPU load for use by frequency policies.
+
 choice CPU_FREQ_POLICY
 	prompt "CPU Frequency Scaling Policy"
 	default CPU_FREQ_POLICY_NONE
@@ -34,6 +44,7 @@ config CPU_FREQ_POLICY_NONE
 
 config CPU_FREQ_POLICY_ON_DEMAND
 	bool "On-demand Policy"
+	select CPU_FREQ_METRIC_CPU_LOAD
 
 endchoice # CPU_FREQ_POLICY
 

--- a/subsys/cpu_freq/cpu_freq.c
+++ b/subsys/cpu_freq/cpu_freq.c
@@ -23,15 +23,10 @@ static void cpu_freq_work_handler(struct k_work *work)
 {
 	uint32_t ret;
 
-	/* 1. Get CPU Load */
-	int load = 50;
-
-	LOG_DBG("Current CPU Load: %d%%", load);
-
-	/* 2. Get next P-state */
+	/* 1. Get next P-state */
 	struct p_state next_p_state;
 
-	ret = cpu_freq_policy_get_p_state_next(&next_p_state, load);
+	ret = cpu_freq_policy_get_p_state_next(&next_p_state);
 	if (ret) {
 		LOG_ERR("Failed to get next P-state: %d", ret);
 		goto reschedule;
@@ -39,7 +34,7 @@ static void cpu_freq_work_handler(struct k_work *work)
 	LOG_DBG("Next P-state: load_threshold=%d, config=%p", next_p_state.load_threshold,
 		next_p_state.config);
 
-	/* 3. Set P-state using P-state driver */
+	/* 2. Set P-state using P-state driver */
 	ret = cpu_freq_performance_state_set(next_p_state);
 	if (ret) {
 		LOG_ERR("Failed to set performance state: %d", ret);

--- a/subsys/cpu_freq/metrics/cpu_load.c
+++ b/subsys/cpu_freq/metrics/cpu_load.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(cpu_freq_metrics_cpu_load, CONFIG_CPU_FREQ_LOG_LEVEL);
+
+static uint64_t execution_cycles_prev;
+static uint64_t total_cycles_prev;
+
+int get_cpu_load(uint32_t *load)
+{
+	int ret;
+	uint64_t execution_cycles;
+	uint64_t total_cycles;
+
+	struct k_thread_runtime_stats cpu_query;
+
+	ret = k_thread_runtime_stats_cpu_get(0, &cpu_query);
+	if (ret) {
+		LOG_ERR("Could not retrieve runtime statistics from scheduler");
+		return ret;
+	}
+
+	execution_cycles = cpu_query.execution_cycles - execution_cycles_prev;
+	total_cycles = cpu_query.total_cycles - total_cycles_prev;
+
+	LOG_DBG("Execution cycles: %llu, Total cycles: %llu", execution_cycles, total_cycles);
+
+	*load = (uint32_t)((100 * total_cycles) / execution_cycles);
+
+	execution_cycles_prev = cpu_query.execution_cycles;
+	total_cycles_prev = cpu_query.total_cycles;
+
+	return 0;
+}

--- a/subsys/cpu_freq/metrics/cpu_load.h
+++ b/subsys/cpu_freq/metrics/cpu_load.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CPU_LOAD_H_
+#define CPU_LOAD_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Get the CPU load as a percentage.
+ *
+ * Return the percent that the CPU has spent in the active (non-idle) state
+ * between calls to this function.
+ *
+ * @param load Pointer to the integer where the CPU load as a percent (0-100) is returned.
+ *
+ * @retval 0 In case of success, nonzero in case of failure.
+ */
+int get_cpu_load(uint32_t *load);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CPU_LOAD_H_ */

--- a/subsys/cpu_freq/policies/on_demand/on_demand.c
+++ b/subsys/cpu_freq/policies/on_demand/on_demand.c
@@ -8,6 +8,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/cpu_freq/policy.h>
 #include <zephyr/cpu_freq/cpu_freq.h>
+#include <metrics/cpu_load.h>
 #include "cpu_freq_soc.h"
 
 LOG_MODULE_REGISTER(cpu_freq_policy_on_demand, CONFIG_CPU_FREQ_LOG_LEVEL);
@@ -20,8 +21,19 @@ const struct p_state *soc_p_states[] = {
  * first P-state where the cpu_load is greater than or equal to the trigger threshold
  * of the P-state.
  */
-uint32_t cpu_freq_policy_get_p_state_next(struct p_state *p_state_out, uint32_t cpu_load)
+int cpu_freq_policy_get_p_state_next(struct p_state *p_state_out)
 {
+	int ret;
+	uint32_t cpu_load;
+
+	ret = get_cpu_load(&cpu_load);
+	if (ret) {
+		LOG_ERR("Unable to retrieve CPU load");
+		return ret;
+	}
+
+	LOG_DBG("Current CPU Load: %d%%", cpu_load);
+
 	for (int i = 0; i < ARRAY_SIZE(soc_p_states); i++) {
 		const struct p_state *state = soc_p_states[i];
 


### PR DESCRIPTION
Implement the CPU load measurement function for use by the CPU frequency scaling subsystem. The statistics used to calculate the load are taken from the scheduler. Specifically, the number of cycles used by the idle thread.